### PR TITLE
A package.json for Windows users

### DIFF
--- a/package-windows.json
+++ b/package-windows.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Windows users: rename this file to `package.json` ",
+  "name": "simple-website-2016",
+  "version": "1.0.0",
+  "description": "A simple website in node js",
+  "private": "true",
+  "main": "server.js",
+  "scripts": {
+	  "build-css": "stylus source/stylesheets/index.styl -o static/css",
+	  "watch-css": "start /b stylus source/stylesheets/index.styl -o static/css -w",
+	  "clean": "if exist static\\css rmdir /q/s static\\css && mkdir static\\css",
+	  "build": "npm run clean && npm run build-css",
+	  "watch": "npm run clean && npm run watch-css && nodemon server -e js,jade",
+	  "start": "node server"	
+  },
+ "author": "Ben Gourley",
+ "license": "ISC",
+  "dependencies": {
+    "express": "^4.14.0",
+    "jade": "^1.11.0",
+    "morgan": "^1.7.0",
+    "nodemon": "^1.9.2",
+    "stylus": "^0.54.5"
+  }
+}


### PR DESCRIPTION
- run watching Stylus process in the background using `start /b`
- Windows specific formatting for `rmdir`, and don't bother if folder doesn't exist

A hackish alternative to renaming files would be to include both syntaxes in one file and change the run command, e.g. 

`npm run win-clean && npm run win-watch`